### PR TITLE
Fix unresolved core dependency from wvlet-log

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val wvletConfig =
     libraryDependencies ++= Seq(
       "org.yaml" % "snakeyaml" % "1.14"
     )
-  ).dependsOn(wvletObj, wvletInject, wvletTest % "test->compile")
+  ).dependsOn(wvletCore, wvletObj, wvletInject, wvletTest % "test->compile")
 
 lazy val wvletCore =
   Project(id = "wvlet-core", base = file("wvlet-core")).settings(


### PR DESCRIPTION
```
[info] Done packaging.
[error] /Users/sasakikai/td-dev/wvlet/wvlet-config/src/main/scala/wvlet/config/YamlReader.scala:6: object core is not a member of package wvlet
[error] import wvlet.core.io.IOUtil._
[error]              ^
[error] /Users/sasakikai/td-dev/wvlet/wvlet-config/src/main/scala/wvlet/config/YamlReader.scala:36: not found: value readAsString
[error]     .load(readAsString(resourcePath))
[error]           ^
[error] /Users/sasakikai/td-dev/wvlet/wvlet-config/src/main/scala/wvlet/config/YamlReader.scala:43: not found: value readAsString
[error]     .load(readAsString(resourcePath))
[error]           ^
[error] three errors found
```
