### PR TITLE
New application configuration flow

### DIFF
--- a/wvlet-config/README.md
+++ b/wvlet-config/README.md
@@ -6,7 +6,7 @@ wvlet-config
 - User specifies an environment (e.g., `test`, `staging`, `production`, etc)
 - Read configuration file (YAML)
   - wvlet-config will search config files from a given `conigpath(s)`
-  - If any configuration for the target environment is not found, it uses `default` configuration.
+  - If no configuration for the target environment is found, it uses `default` configuration.
 
 - Supply additional configurations (e.g., confidential information such as password, apikey, etc.)
   - Read these configurations in a secure manner and create a `Properties` object.

--- a/wvlet-config/README.md
+++ b/wvlet-config/README.md
@@ -54,7 +54,7 @@ server.password=xxxxxyyyyyy
 
 code:
 ```scala
-import wvlet.config.ConfigBuilder
+import wvlet.config.Config
 import wvlet.obj.tag.@@
 
 // Configulation classes can have default values
@@ -67,7 +67,7 @@ trait Access
 trait Db
 
 val config = 
-  ConfigBuilder(env="development", configPaths="./config")
+  Config.newBuilder(env="development", configPaths="./config")
     .registerFromYaml[LogConfig @@ Access]("access-log.yml")
     .registerFromYaml[LogConfig @@ Db]("db-log.yml")
     .registerFromYaml[ServerConfig]("server.yml")

--- a/wvlet-config/README.md
+++ b/wvlet-config/README.md
@@ -3,21 +3,16 @@ wvlet-config
 
 ## Application configuration flow
 
-- User specified an environment (e.g., `test`, `staging`, `production`, etc)
+- User specifies an environment (e.g., `test`, `staging`, `production`, etc)
 - Read configuration file (YAML)
   - wvlet-config will search config files from a given `conigpath(s)`
-  - Pick object of the target environment
   - If any configuration for the target configuration is not found, use `default` configuration.
 
-- Mapping configuraion to Scala case class
-
 - Supply the configuration (e.g., confidential information such as password, apikey, etc.)
-  - Read these configuratios using your favorite way
-  - Override a part of your configuration
+  - Read these configurations in a secure manner
+  - Override a part of your configurations
 
-- Enable retrieving these configuration from your program
-  - wvlet-inject
-
+- Use ConfigBuider to build configurations
 
 
 ## Usage
@@ -41,7 +36,7 @@ default:
   host: localhost
   port: 8080
 
-# Override port paraameter for development
+# Override port number for development
 development:
   <<: *default
   port: 9000
@@ -59,7 +54,7 @@ server.password=xxxxxyyyyyy
 
 code:
 ```scala
-import wvlet.config
+import wvlet.config.ConfigBuilder
 import wvlet.obj.tag.@@
 
 // Configulation classes can have default values
@@ -67,7 +62,7 @@ import wvlet.obj.tag.@@
 case class LogConfig(file:String, maxFiles:Int=100, maxSize:Int=10485760)
 case class ServerConfig(host:String, port:Int, password:String)
 
-// Type tag to use same configuration objects for different purposes
+// To use the same configuration class for different purposes, use type tag (@@ Tag)
 trait Access
 trait Db
 

--- a/wvlet-config/README.md
+++ b/wvlet-config/README.md
@@ -1,0 +1,92 @@
+wvlet-config
+===
+
+## Application configuration flow
+
+- User specified an environment (e.g., `test`, `staging`, `production`, etc)
+- Read configuration file (YAML)
+  - wvlet-config will search config files from a given `conigpath(s)`
+  - Pick object of the target environment
+  - If any configuration for the target configuration is not found, use `default` configuration.
+
+- Mapping configuraion to Scala case class
+
+- Supply the configuration (e.g., confidential information such as password, apikey, etc.)
+  - Read these configuratios using your favorite way
+  - Override a part of your configuration
+
+- Enable retrieving these configuration from your program
+  - wvlet-inject
+
+
+
+## Usage
+
+`config/access-log.yml`:
+```
+default:
+  file: log/access.log
+  max_files: 50
+```
+
+`config/db-log.yml`:
+```
+default:
+  file: log/db.log
+```
+
+`config/server.yml`
+```
+default:
+  host: localhost
+  port: 8080
+
+# Override port paraameter for development
+development:
+  <<: *default
+  port: 9000
+```
+
+`config.properties`:
+```
+# ([tag].)?[prefix].[param]=(value)
+access.log.file=/path/to/access.log
+db.log.file=/path/to/db.log
+db.log.max_files=250
+server.host=mydomain.com
+server.password=xxxxxyyyyyy
+```
+
+code:
+```scala
+import wvlet.config
+import wvlet.obj.tag.@@
+
+// Configulation classes can have default values
+// Configuration class names become prefixes by removing Config
+case class LogConfig(file:String, maxFiles:Int=100, maxSize:Int=10485760)
+case class ServerConfig(host:String, port:Int, password:String)
+
+// Type tag to use same configuration objects for different purposes
+trait Access
+trait Db
+
+val config = 
+  ConfigBuilder(env="development", configPaths="./config")
+    .registerFromYaml[LogConfig @@ Access]("access-log.yml")
+    .registerFromYaml[LogConfig @@ Db]("db-log.yml")
+    .registerFromYaml[ServerConfig]("server.yml")
+    .overrideWithPropertiesFile("config.properties")
+    .build
+    
+val accessLogConfig = config.of[LogConfig @@ Access]
+// LogConfig("/path/to/access.log",50,104857600)
+
+val dbLogConfig = config.of[LogConfig @@ Db]
+// LogConfig("/path/to/db.log",250,104857600)
+
+val serverConfig = config.of[ServerConfig]
+// ServerConfig(host="mydomain.com",port=9000,password="xxxxxyyyyyy")
+
+```
+

--- a/wvlet-config/README.md
+++ b/wvlet-config/README.md
@@ -5,7 +5,7 @@ wvlet-config
 
 - User specifies an environment (e.g., `test`, `staging`, `production`, etc)
 - Read configuration file (YAML)
-  - wvlet-config will search config files from a given `conigpath(s)`
+  - wvlet-config will search config files from a given `configpath(s)`
   - If no configuration for the target environment is found, it uses `default` configuration.
 
 - Supply additional configurations (e.g., confidential information such as password, apikey, etc.)

--- a/wvlet-config/README.md
+++ b/wvlet-config/README.md
@@ -17,20 +17,20 @@ wvlet-config
 
 ## Usage
 
-`config/access-log.yml`:
+**config/access-log.yml**:
 ```
 default:
   file: log/access.log
   max_files: 50
 ```
 
-`config/db-log.yml`:
+**config/db-log.yml**:
 ```
 default:
   file: log/db.log
 ```
 
-`config/server.yml`
+**config/server.yml**
 ```
 default:
   host: localhost
@@ -42,7 +42,7 @@ development:
   port: 9000
 ```
 
-`config.properties`:
+**config.properties**:
 ```
 # ([tag].)?[prefix].[param]=(value)
 access.log.file=/path/to/access.log

--- a/wvlet-config/README.md
+++ b/wvlet-config/README.md
@@ -6,11 +6,11 @@ wvlet-config
 - User specifies an environment (e.g., `test`, `staging`, `production`, etc)
 - Read configuration file (YAML)
   - wvlet-config will search config files from a given `conigpath(s)`
-  - If any configuration for the target configuration is not found, use `default` configuration.
+  - If any configuration for the target environment is not found, it uses `default` configuration.
 
-- Supply the configuration (e.g., confidential information such as password, apikey, etc.)
-  - Read these configurations in a secure manner
-  - Override a part of your configurations
+- Supply additional configurations (e.g., confidential information such as password, apikey, etc.)
+  - Read these configurations in a secure manner and create a `Properties` object.
+  - Override your configurations with this `Properties` object.
 
 - Use ConfigBuider to build configurations
 
@@ -58,7 +58,7 @@ import wvlet.config.Config
 import wvlet.obj.tag.@@
 
 // Configulation classes can have default values
-// Configuration class names become prefixes by removing Config
+// Configuration class name convention: xxxxConfig (xxxx will be the prefix)
 case class LogConfig(file:String, maxFiles:Int=100, maxSize:Int=10485760)
 case class ServerConfig(host:String, port:Int, password:String)
 

--- a/wvlet-config/src/main/scala/wvlet/config/Config.scala
+++ b/wvlet-config/src/main/scala/wvlet/config/Config.scala
@@ -27,21 +27,24 @@ object Config {
     sys.props.getOrElse("prog.home", "") // program home
   )
 
-  def newBuilder(env: String, configPaths: Seq[String]=defaultConfigPath): ConfigBuilder
-  = new ConfigBuilderImpl(Environment(env), cleanupConfigPaths(configPaths))
+  def newBuilder(env: String, configPaths: String): ConfigBuilder
+  = new ConfigBuilder(Environment(env), cleanupConfigPaths(configPaths.split(":")))
+
+  def newBuilder(env: String, configPaths: Seq[String] = defaultConfigPath): ConfigBuilder
+  = new ConfigBuilder(Environment(env), cleanupConfigPaths(configPaths))
 
   def newBuilder(env: Environment, configPaths: Seq[String]): ConfigBuilder =
-    new ConfigBuilderImpl(env, cleanupConfigPaths(configPaths))
+    new ConfigBuilder(env, cleanupConfigPaths(configPaths))
 
-  private def cleanupConfigPaths(paths:Seq[String]) = {
+  private def cleanupConfigPaths(paths: Seq[String]) = {
     val b = Seq.newBuilder[String]
-    for(p <- paths) {
-      if(!p.isEmpty) {
+    for (p <- paths) {
+      if (!p.isEmpty) {
         b += p
       }
     }
     val result = b.result()
-    if(result.isEmpty) {
+    if (result.isEmpty) {
       Seq(".") // current directory
     }
     else {
@@ -55,7 +58,7 @@ case class ConfigHolder(env: String, tpe: ObjectType, value: Any)
 trait Config extends Iterable[ConfigHolder] {
   def of[ConfigType](implicit tag: ru.TypeTag[ConfigType]): ConfigType
   def bindConfigs(i: Inject)
-  def getAll : Seq[ConfigHolder]
+  def getAll: Seq[ConfigHolder]
 }
 
 case class ConfigPaths(configPaths: Seq[String]) extends LogSupport {

--- a/wvlet-config/src/main/scala/wvlet/config/ConfigBuilder.scala
+++ b/wvlet-config/src/main/scala/wvlet/config/ConfigBuilder.scala
@@ -30,11 +30,9 @@ import scala.util.{Failure, Success, Try}
 object ConfigBuilder extends LogSupport {
   def apply(env: String, configPaths: String) = new ConfigBuilder(Environment(env), configPaths.split(":"))
 
-
-
   private[config] def extractPrefix(t: ObjectType): ConfigPrefix = {
 
-    def canonicalize(s:String) : String = {
+    def canonicalize(s: String): String = {
       val name = s.replaceAll("Config$", "")
       CanonicalNameFormatter.format(name)
     }
@@ -49,7 +47,7 @@ object ConfigBuilder extends LogSupport {
 
   case class ConfigPrefix(tag: Option[String], prefix: String)
   case class ConfigParamKey(prefix: ConfigPrefix, param: String)
-  case class ConfigParam(key:ConfigParamKey, v:Any)
+  case class ConfigParam(key: ConfigParamKey, v: Any)
 
   private[config] def configToProps(configHolder: ConfigHolder): Seq[ConfigParam] = {
     val prefix = extractPrefix(configHolder.tpe)
@@ -149,7 +147,7 @@ class ConfigBuilder(env: Environment, configPaths: Seq[String]) extends LogSuppo
 
   def overrideWithPropertiesFile(propertiesFile: String): ConfigBuilder = {
     val propPath = findConfigFile(propertiesFile)
-    val props = withResource(new FileInputStream(propertiesFile)) { in =>
+    val props = withResource(new FileInputStream(propPath)) { in =>
       val p = new Properties()
       p.load(in)
       p
@@ -157,7 +155,7 @@ class ConfigBuilder(env: Environment, configPaths: Seq[String]) extends LogSuppo
     overrideWithProperties(props)
   }
 
-  def overrideWithProperties(props:Properties) : ConfigBuilder = {
+  def overrideWithProperties(props: Properties): ConfigBuilder = {
     val overrides = {
       val b = Seq.newBuilder[ConfigParam]
       for ((k, v) <- props) yield {
@@ -173,7 +171,7 @@ class ConfigBuilder(env: Environment, configPaths: Seq[String]) extends LogSuppo
       val b = ObjectBuilder.fromObject(c.value)
       val prefix = extractPrefix(c.tpe)
       val overrideParams = overrides.filter(_.key.prefix == prefix)
-      for(p <- overrideParams) {
+      for (p <- overrideParams) {
         trace(s"override: ${p}")
         b.set(p.key.param, p.v)
       }

--- a/wvlet-config/src/main/scala/wvlet/config/ConfigBuilder.scala
+++ b/wvlet-config/src/main/scala/wvlet/config/ConfigBuilder.scala
@@ -13,34 +13,88 @@
  */
 package wvlet.config
 
-import java.io.{File, FileNotFoundException}
+import java.io.{File, FileInputStream, FileNotFoundException}
+import java.util.Properties
 
-import wvlet.log.{LogSupport, Logger}
-import wvlet.obj.ObjectType
+import wvlet.config.IOUtil._
+import wvlet.config.YamlReader.loadMapOf
+import wvlet.log.LogSupport
+import wvlet.obj.ObjectBuilder.CanonicalNameFormatter
+import wvlet.obj.{ObjectBuilder, ObjectSchema, ObjectType, TaggedObjectType}
 
+import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.{universe => ru}
+import scala.util.{Failure, Success, Try}
 
-trait ConfigBuilder {
-  def build: Config
-  def registerFromYaml[ConfigType: ru.TypeTag](configFilePath: String): ConfigBuilder
-  def register[ConfigType: ru.TypeTag](config: ConfigType): ConfigBuilder
-  def addAll(config: Config): ConfigBuilder
-  def add(config: ConfigHolder): ConfigBuilder
+object ConfigBuilder extends LogSupport {
+  def apply(env: String, configPaths: String) = new ConfigBuilder(Environment(env), configPaths.split(":"))
+
+
+
+  private[config] def extractPrefix(t: ObjectType): ConfigPrefix = {
+
+    def canonicalize(s:String) : String = {
+      val name = s.replaceAll("Config$", "")
+      CanonicalNameFormatter.format(name)
+    }
+
+    t match {
+      case TaggedObjectType(raw, base, taggedType) =>
+        ConfigPrefix(Some(CanonicalNameFormatter.format(taggedType.name)), canonicalize(base.name))
+      case _ =>
+        ConfigPrefix(None, canonicalize(t.name))
+    }
+  }
+
+  case class ConfigPrefix(tag: Option[String], prefix: String)
+  case class ConfigParamKey(prefix: ConfigPrefix, param: String)
+  case class ConfigParam(key:ConfigParamKey, v:Any)
+
+  private[config] def configToProps(configHolder: ConfigHolder): Seq[ConfigParam] = {
+    val prefix = extractPrefix(configHolder.tpe)
+    val schema = ObjectSchema.of(configHolder.tpe)
+    val b = Seq.newBuilder[ConfigParam]
+    for (p <- schema.parameters) yield {
+      val key = ConfigParamKey(prefix, CanonicalNameFormatter.format(p.name))
+      Try(p.get(configHolder.value)) match {
+        case Success(v) => b += ConfigParam(key, v)
+        case Failure(e) =>
+          warn(s"Failed to read parameter ${p} from ${configHolder}")
+      }
+    }
+    b.result()
+  }
+
+  private[config] def toConfigKey(propKey: String): ConfigParamKey = {
+    val c = propKey.split("\\.")
+    c.length match {
+      case l if l >= 3 =>
+        val tag = c(0)
+        val prefix = c(1)
+        val param = CanonicalNameFormatter.format(c.drop(2).mkString)
+        ConfigParamKey(ConfigPrefix(Some(tag), prefix), param)
+      case l if l == 2 =>
+        val prefix = c(0)
+        val param = CanonicalNameFormatter.format(c(1))
+        ConfigParamKey(ConfigPrefix(None, prefix), param)
+      case other =>
+        throw new IllegalArgumentException(s"${propKey} should have ([tag].)?[prefix].[param] format")
+    }
+  }
+
 }
 
+import wvlet.config.ConfigBuilder._
 
 /**
   *
   */
-class ConfigBuilderImpl(env: Environment, configPaths: Seq[String]) extends ConfigBuilder {
+class ConfigBuilder(env: Environment, configPaths: Seq[String]) extends LogSupport {
 
-  private val logger = Logger.of[ConfigBuilder]
-
-  logger.info(s"Config file paths: [${configPaths.mkString(", ")}]")
   require(!configPaths.isEmpty, "configPaths is empty")
 
-  private var configHolder = Seq.newBuilder[ConfigHolder]
+  private val configHolder = Seq.newBuilder[ConfigHolder]
 
   private def findConfigFile(name: String): String = {
     configPaths
@@ -60,15 +114,6 @@ class ConfigBuilderImpl(env: Environment, configPaths: Seq[String]) extends Conf
     this
   }
 
-  def build: Config = {
-    // Override previous occurrences of the same type config
-    val b = Map.newBuilder[ObjectType, ConfigHolder]
-    for (s <- configHolder.result) {
-      b += s.tpe -> s
-    }
-    new ConfigImpl(b.result().values.toIndexedSeq)
-  }
-
   def register[ConfigType](config: ConfigType)(implicit tag: ru.TypeTag[ConfigType]): ConfigBuilder = {
     val tpe = ObjectType.ofTypeTag(tag)
     configHolder += ConfigHolder(env.env, tpe, config)
@@ -81,15 +126,15 @@ class ConfigBuilderImpl(env: Environment, configPaths: Seq[String]) extends Conf
     val cls = tpe.rawType
     val realPath = findConfigFile(configFilePath)
 
-    val m = YamlReader.loadMapOf[ConfigType](realPath)(ClassTag(cls))
+    val m = loadMapOf[ConfigType](realPath)(ClassTag(cls))
     val config = m.get(env.env) match {
       case Some(x) =>
-        logger.info(s"Loading ${tpe} config from ${realPath}, env:${env}")
+        info(s"Loading ${tpe} config from ${realPath}, env:${env}")
         x
       case None =>
         // Load default
-        logger.debug(s"Configuration for ${env.env} is not found in ${realPath}. Load ${env.defaultEnv} configuration instead")
-        logger.info(s"Loading ${tpe} from ${realPath}, env:${env} <= used env:${env.defaultEnv}")
+        debug(s"Configuration for ${env.env} is not found in ${realPath}. Load ${env.defaultEnv} configuration instead")
+        info(s"Loading ${tpe} from ${realPath}, env:${env} <= used env:${env.defaultEnv}")
         m.getOrElse(
           env.defaultEnv, {
             val m = s"No config for ${tpe} is found for ${env.defaultEnv} within ${realPath}"
@@ -100,5 +145,51 @@ class ConfigBuilderImpl(env: Environment, configPaths: Seq[String]) extends Conf
     }
     configHolder += ConfigHolder(env.env, tpe, config)
     this
+  }
+
+  def overrideWithPropertiesFile(propertiesFile: String): ConfigBuilder = {
+    val propPath = findConfigFile(propertiesFile)
+    val props = withResource(new FileInputStream(propertiesFile)) { in =>
+      val p = new Properties()
+      p.load(in)
+      p
+    }
+    overrideWithProperties(props)
+  }
+
+  def overrideWithProperties(props:Properties) : ConfigBuilder = {
+    val overrides = {
+      val b = Seq.newBuilder[ConfigParam]
+      for ((k, v) <- props) yield {
+        val key = toConfigKey(k)
+        b += ConfigParam(key, v)
+      }
+      b.result
+    }
+
+    val currentConfigs = configHolder.result()
+    configHolder.clear()
+    for (c <- currentConfigs) {
+      val b = ObjectBuilder.fromObject(c.value)
+      val prefix = extractPrefix(c.tpe)
+      val overrideParams = overrides.filter(_.key.prefix == prefix)
+      for(p <- overrideParams) {
+        trace(s"override: ${p}")
+        b.set(p.key.param, p.v)
+      }
+      val newConfig = b.build
+      configHolder += ConfigHolder(c.env, c.tpe, newConfig)
+    }
+
+    this
+  }
+
+  def build: Config = {
+    // Override previous occurrences of the same type config
+    val b = Map.newBuilder[ObjectType, ConfigHolder]
+    for (s <- configHolder.result) {
+      b += s.tpe -> s
+    }
+    new ConfigImpl(b.result().values.toIndexedSeq)
   }
 }

--- a/wvlet-config/src/main/scala/wvlet/config/ConfigBuilder.scala
+++ b/wvlet-config/src/main/scala/wvlet/config/ConfigBuilder.scala
@@ -129,7 +129,7 @@ class ConfigBuilder(env: Environment, configPaths: Seq[String]) extends LogSuppo
     val m = loadMapOf[ConfigType](realPath)(ClassTag(cls))
     val config = m.get(env.env) match {
       case Some(x) =>
-        info(s"Loading ${tpe} config from ${realPath}, env:${env}")
+        info(s"Loading ${tpe} from ${realPath}, env:${env}")
         x
       case None =>
         // Load default

--- a/wvlet-config/src/main/scala/wvlet/config/IOUtil.scala
+++ b/wvlet-config/src/main/scala/wvlet/config/IOUtil.scala
@@ -29,6 +29,17 @@ object IOUtil {
     }
   }
 
+  def withTempFile[U](name:String, dir:String="target", suffix:String = ".tmp")(body:File => U) = {
+    val f = File.createTempFile(name, suffix, new File(dir))
+    try {
+      body(f)
+    }
+    finally {
+      f.delete()
+    }
+  }
+
+
   def readAsString(resourcePath: String) = {
     require(resourcePath != null, s"resourcePath is null")
     val file = findPath(new File(resourcePath))

--- a/wvlet-config/src/main/scala/wvlet/config/IOUtil.scala
+++ b/wvlet-config/src/main/scala/wvlet/config/IOUtil.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.config
+
+import java.io._
+import java.nio.charset.StandardCharsets
+
+/**
+  *
+  */
+object IOUtil {
+  def withResource[Resource <: AutoCloseable, U](resource: Resource)(body: Resource => U): U = {
+    try {
+      body(resource)
+    }
+    finally {
+      resource.close
+    }
+  }
+
+  def readAsString(resourcePath: String) = {
+    require(resourcePath != null, s"resourcePath is null")
+    val file = findPath(new File(resourcePath))
+    if (!file.exists()) {
+      throw new FileNotFoundException(s"${file} is not found")
+    }
+    readFully(new FileInputStream(file)) {
+      data => new String(data, StandardCharsets.UTF_8)
+    }
+  }
+
+  def readFully[U](in: InputStream)(f: Array[Byte] => U): U = {
+    val byteArray = withResource(new ByteArrayOutputStream) {
+      b =>
+        val buf = new Array[Byte](8192)
+        withResource(in) {
+          src =>
+            var readBytes = 0
+            while ( {
+              readBytes = src.read(buf);
+              readBytes != -1
+            }) {
+              b.write(buf, 0, readBytes)
+            }
+        }
+        b.toByteArray
+    }
+    f(byteArray)
+  }
+
+  def findPath(path: String): File = findPath(new File(path))
+
+  def findPath(path: File): File = {
+    if (path.exists()) {
+      path
+    }
+    else {
+      val defaultPath = new File(new File(System.getProperty("prog.home", "")), path.getPath)
+      if (!defaultPath.exists()) {
+        throw new FileNotFoundException(s"${path} is not found")
+      }
+      defaultPath
+    }
+  }
+}

--- a/wvlet-config/src/main/scala/wvlet/config/YamlReader.scala
+++ b/wvlet-config/src/main/scala/wvlet/config/YamlReader.scala
@@ -13,11 +13,10 @@
  */
 package wvlet.config
 
-import java.io._
-import java.nio.charset.StandardCharsets
 import java.{util => ju}
 
 import org.yaml.snakeyaml.Yaml
+import wvlet.config.IOUtil._
 import wvlet.log.LogSupport
 import wvlet.obj.ObjectBuilder
 
@@ -27,60 +26,6 @@ import scala.collection.immutable.ListMap
 import scala.reflect.ClassTag
 
 object YamlReader extends LogSupport {
-
-  private def withResource[Resource <: AutoCloseable, U](resource: Resource)(body: Resource => U): U = {
-    try {
-      body(resource)
-    }
-    finally {
-      resource.close
-    }
-  }
-
-  private def readAsString(resourcePath: String) = {
-    require(resourcePath != null, s"resourcePath is null")
-    val file = findPath(new File(resourcePath))
-    if (!file.exists()) {
-      throw new FileNotFoundException(s"${file} is not found")
-    }
-    readFully(new FileInputStream(file)) {
-      data => new String(data, StandardCharsets.UTF_8)
-    }
-  }
-
-  private def readFully[U](in: InputStream)(f: Array[Byte] => U): U = {
-    val byteArray = withResource(new ByteArrayOutputStream) {
-      b =>
-        val buf = new Array[Byte](8192)
-        withResource(in) {
-          src =>
-            var readBytes = 0
-            while ( {
-              readBytes = src.read(buf);
-              readBytes != -1
-            }) {
-              b.write(buf, 0, readBytes)
-            }
-        }
-        b.toByteArray
-    }
-    f(byteArray)
-  }
-
-  private def findPath(path: String): File = findPath(new File(path))
-
-  private def findPath(path: File): File = {
-    if (path.exists()) {
-      path
-    }
-    else {
-      val defaultPath = new File(new File(System.getProperty("prog.home", "")), path.getPath)
-      if (!defaultPath.exists()) {
-        throw new FileNotFoundException(s"${path} is not found")
-      }
-      defaultPath
-    }
-  }
 
   def load[A](resourcePath: String, env: String)(implicit m: ClassTag[A]): A = {
     val map = loadMapOf[A](resourcePath)

--- a/wvlet-config/src/test/scala/wvlet/config/ConfigTest.scala
+++ b/wvlet-config/src/test/scala/wvlet/config/ConfigTest.scala
@@ -13,13 +13,15 @@
  */
 package wvlet.config
 
+import java.util.Properties
+
 import wvlet.obj.tag.@@
 import wvlet.test.WvletSpec
 
 trait AppScope
 trait SessionScope
 
-case class MyConfig(id: Int, fullName: String)
+case class SampleConfig(id: Int, fullName: String)
 
 /**
   *
@@ -28,17 +30,16 @@ class ConfigTest extends WvletSpec {
 
   val configPaths = Seq("wvlet-config/src/test/resources")
 
-  def loadConfig(env:String) =
+  def loadConfig(env: String) =
     Config.newBuilder(env = env, configPaths = configPaths)
-    .registerFromYaml[MyConfig]("myconfig.yml")
+    .registerFromYaml[SampleConfig]("myconfig.yml")
     .build
-
 
   "Config" should {
     "map yaml file into a case class" in {
       val config = loadConfig("default")
 
-      val c1 = config.of[MyConfig]
+      val c1 = config.of[SampleConfig]
       c1.id shouldBe 1
       c1.fullName shouldBe "default-config"
     }
@@ -46,47 +47,68 @@ class ConfigTest extends WvletSpec {
     "read different env config" in {
       val config = loadConfig("staging")
 
-      val c = config.of[MyConfig]
+      val c = config.of[SampleConfig]
       c.id shouldBe 2
       c.fullName shouldBe "staging-config"
     }
 
     "allow override" in {
       val config = Config.newBuilder(env = "staging", configPaths = configPaths)
-                   .registerFromYaml[MyConfig]("myconfig.yml")
-                   .register[MyConfig](MyConfig(10, "hello"))
+                   .registerFromYaml[SampleConfig]("myconfig.yml")
+                   .register[SampleConfig](SampleConfig(10, "hello"))
                    .build
 
-      val c = config.of[MyConfig]
+      val c = config.of[SampleConfig]
       c.id shouldBe 10
       c.fullName shouldBe "hello"
     }
 
     "create a new config based on existing one" in {
-      val config = Config.newBuilder(env="default", configPaths = configPaths)
-                   .registerFromYaml[MyConfig]("myconfig.yml")
+      val config = Config.newBuilder(env = "default", configPaths = configPaths)
+                   .registerFromYaml[SampleConfig]("myconfig.yml")
                    .build
 
-      val config2 = Config.newBuilder(env="production", configPaths = configPaths)
+      val config2 = Config.newBuilder(env = "production", configPaths = configPaths)
                     .addAll(config)
                     .build
 
-      val c2 = config2.of[MyConfig]
+      val c2 = config2.of[SampleConfig]
       c2.id shouldBe 1
       c2.fullName shouldBe "default-config"
     }
 
-    "read tagged type" taggedAs("tag") in {
-      val config = Config.newBuilder(env="default", configPaths = configPaths)
-                   .registerFromYaml[MyConfig @@ AppScope]("myconfig.yml")
-                   .register[MyConfig @@ SessionScope](MyConfig(2, "session").asInstanceOf[MyConfig @@ SessionScope])
+    "read tagged type" taggedAs ("tag") in {
+      val config = Config.newBuilder(env = "default", configPaths = configPaths)
+                   .registerFromYaml[SampleConfig @@ AppScope]("myconfig.yml")
+                   .register[SampleConfig @@ SessionScope](SampleConfig(2, "session").asInstanceOf[SampleConfig @@ SessionScope])
                    .build
 
-      val c = config.of[MyConfig @@ AppScope]
-      c shouldBe MyConfig(1, "default-config")
+      val c = config.of[SampleConfig @@ AppScope]
+      c shouldBe SampleConfig(1, "default-config")
 
-      val s = config.of[MyConfig @@ SessionScope]
-      s shouldBe MyConfig(2, "session")
+      val s = config.of[SampleConfig @@ SessionScope]
+      s shouldBe SampleConfig(2, "session")
     }
+
+    "override values with properties" taggedAs ("props") in {
+
+      val p = new Properties
+      p.setProperty("sample.id", "10")
+      p.setProperty("appscope.sample.id", "2")
+      p.setProperty("appscope.sample.full_name", "hellohello")
+
+      val config = Config.newBuilder(env = "devault", configPaths = configPaths)
+                   .register[SampleConfig](SampleConfig(1, "hello"))
+                   .register[SampleConfig @@ AppScope](SampleConfig(1, "hellohello").asInstanceOf[SampleConfig @@ AppScope])
+                   .overrideWithProperties(p)
+                   .build
+
+      val c = config.of[SampleConfig]
+      c shouldBe SampleConfig(10, "hello")
+
+      val c2 = config.of[SampleConfig@@AppScope]
+      c2 shouldBe SampleConfig(2, "hellohello")
+    }
+
   }
 }

--- a/wvlet-obj/src/main/scala/wvlet/obj/ObjectBuilder.scala
+++ b/wvlet-obj/src/main/scala/wvlet/obj/ObjectBuilder.scala
@@ -39,6 +39,15 @@ object ObjectBuilder extends LogSupport {
     new SimpleObjectBuilder(cl)
   }
 
+  def fromObject[A](obj:A) : ObjectBuilder[_] = {
+    val b = new SimpleObjectBuilder(obj.getClass)
+    val schema = ObjectSchema.getSchemaOf(obj)
+    for(p <- schema.parameters) {
+      b.set(p.name, p.get(obj))
+    }
+    b
+  }
+
   sealed trait BuilderElement
   case class Holder[A](holder: ObjectBuilder[A]) extends BuilderElement
   case class Value(value: Any) extends BuilderElement

--- a/wvlet-obj/src/main/scala/wvlet/obj/ObjectSchema.scala
+++ b/wvlet-obj/src/main/scala/wvlet/obj/ObjectSchema.scala
@@ -102,6 +102,8 @@ object ObjectSchema extends LogSupport {
     */
   def apply(cl: Class[_]): ObjectSchema = schemaTable.getOrElseUpdate(cl, createSchema(cl))
 
+  def of(tpe: ObjectType) : ObjectSchema = ObjectSchema(tpe.rawType)
+
   private def createSchema(cl: Class[_]): ObjectSchema = {
     trace(s"createSchema of ${cl}")
     new ObjectSchema(cl, parametersOf(cl))


### PR DESCRIPTION
@Lewuathe 

Added a support for a new configuration flow to avoid generating YAML files in production. 

Basically this flow uses default configurations given by config/xxx.yml files. 
- The yaml file contains configurations for various environments. 
- If configurations for the target environment is not found in the YAML file, it uses the configurations for `default` environment. 
- To provide confidential information (e.g, apikey, password, etc.), we can use Properties object. This avoid the burden of generating YAML files in deployment scripts.
