### PR TITLE
LogLevelScanner improvement

### DIFF
--- a/wvlet-log/src/main/scala/wvlet/log/Guard.scala
+++ b/wvlet-log/src/main/scala/wvlet/log/Guard.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.log
+
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+  *
+  */
+trait Guard {
+  private[this] val lock = new ReentrantLock()
+  protected def newCondition = lock.newCondition()
+
+  def guard[U](body: => U) : U = {
+    lock.lockInterruptibly()
+    try {
+      body
+    }
+    finally {
+      lock.unlock()
+    }
+  }
+}

--- a/wvlet-log/src/main/scala/wvlet/log/LogLevelScanner.scala
+++ b/wvlet-log/src/main/scala/wvlet/log/LogLevelScanner.scala
@@ -108,18 +108,19 @@ private[log] class LogLevelScanner extends Guard {
   private val state = new AtomicReference[ScannerState](STOPPED)
 
   def start {
-    if (state.compareAndSet(STOPPED, RUNNING)) {
-      // Create a new thread if the previous thread is terminated
-      new LogLevelScannerThread().start
+    guard {
+      state.compareAndSet(STOPPING, RUNNING)
+      if (state.compareAndSet(STOPPED, RUNNING)) {
+        // Create a new thread if the previous thread is terminated
+        new LogLevelScannerThread().start
+      }
     }
-    else if (state.compareAndSet(STOPPING, RUNNING)) {
-      // reuse the thread
-    }
-    // Do nothing if it is already started
   }
 
   def stop {
-    state.set(STOPPING)
+    guard {
+      state.set(STOPPING)
+    }
   }
 
   private var lastScheduledMillis: Option[Long] = None

--- a/wvlet-log/src/test/scala/wvlet/log/LogLevelScannerTest.scala
+++ b/wvlet-log/src/test/scala/wvlet/log/LogLevelScannerTest.scala
@@ -47,15 +47,17 @@ class LogLevelScannerTest extends Spec {
 
       // Wait the first scan
       Thread.sleep(1000)
+      Logger.stopScheduledLogLevelScan
+
       l.getLogLevel shouldBe LogLevel.DEBUG
     }
 
     "load another loglevel file" in {
       val l = Logger("wvlet.log.test")
       l.setLogLevel(LogLevel.WARN)
-
-      Logger.scheduleLogLevelScan(Seq("wvlet/log/custom-log.properties"), Duration(15, TimeUnit.SECONDS))
+      Logger.scheduleLogLevelScan(LogLevelScannerConfig(Seq("wvlet/log/custom-log.properties"), Duration(500, TimeUnit.MILLISECONDS)))
       Thread.sleep(1000)
+      Logger.stopScheduledLogLevelScan
       l.getLogLevel shouldBe LogLevel.ERROR
     }
 
@@ -63,9 +65,9 @@ class LogLevelScannerTest extends Spec {
       val l = Logger("wvlet.log.test")
       l.setLogLevel(LogLevel.TRACE)
 
-      Logger.scheduleLogLevelScan(Seq("wvlet/log/invalid-loglevel.properties"), Duration(15, TimeUnit.SECONDS))
+      Logger.scheduleLogLevelScan(LogLevelScannerConfig(Seq("wvlet/log/invalid-loglevel.properties"), Duration(500, TimeUnit.MILLISECONDS)))
       Thread.sleep(1000)
-
+      Logger.stopScheduledLogLevelScan
       // Should ignore unknown log level string
       l.getLogLevel shouldBe LogLevel.TRACE
     }

--- a/wvlet-test/src/main/scala/wvlet/test/WvletSpec.scala
+++ b/wvlet-test/src/main/scala/wvlet/test/WvletSpec.scala
@@ -31,8 +31,12 @@ trait WvletSpec extends WordSpec
   // Add source code location to the debug logs
   Logger.setDefaultFormatter(SourceCodeLogFormatter)
 
-  // Periodically scan log level file
-  Logger.scheduleLogLevelScan
-
   implicit def toTag(s:String) = Tag(s)
+  override def run(testName: Option[String], args: Args): Status = {
+    // Periodically scan log level file
+    Logger.scheduleLogLevelScan
+    val s = super.run(testName, args)
+    Logger.stopScheduledLogLevelScan
+    s
+  }
 }


### PR DESCRIPTION
- Reuse LogLevelScanner threads if it still exists
  - Scan configuration can be changed later
- Keep alive LogLevelScanner thread for a while (up to scanDuration) after stop() is called, so that we can reuse the thread

This fixes a problem that LogLevelScanner threads remains in the JVM (especially when running sbt test)
